### PR TITLE
Correct `uses:` line to reference the branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Mirror action step
       id: mirror
-      uses: google/mirror-branch-action
+      uses: google/mirror-branch-action@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'SOURCE_BRANCH_NAME'

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Mirror action step
       id: mirror
-      uses: google/mirror-branch-action@main
+      uses: google/mirror-branch-action@v1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'SOURCE_BRANCH_NAME'


### PR DESCRIPTION
A `uses:` line in a GitHub Action YML script must reference a branch with `@`. The example in `README.md` does not, which will cause errors if you copy it verbatim:

https://github.com/brycelelbach/github_pages_testing/actions/runs/164014798
