### PR TITLE
Unify placeholders in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ on:
 jobs:
   mirror_job:
     runs-on: ubuntu-latest
-    name: Mirror SOURCE to DEST
+    name: Mirror SOURCE_BRANCH_NAME branch to DESTINATION_BRANCH_NAME branch
     steps:
     - name: Mirror action step
       id: mirror


### PR DESCRIPTION
A colleague of mine suggested using the same placeholder in the GitHub action name for easy search and replace.